### PR TITLE
Fixes layout issue on smaller screens

### DIFF
--- a/src/components/phq9/PHQ9.js
+++ b/src/components/phq9/PHQ9.js
@@ -4,9 +4,11 @@ import PHQ9ResultsTable from './PHQ9ResultsTable';
 
 const PHQ9 = ({ responses }) => {
     return (
-        <Card className="p-2 m-2 d-flex flex-column align-items-center justify-content-center shadow">
+        <Card className="p-2 m-2 d-flex flex-column align-items-center justify-content-center shadow" style={{ maxWidth: '100%' }}>
             <p className="lead">PHQ-9 Responses</p>
-            <PHQ9ResultsTable responses={responses.entry} />
+            <div style={{ overflowX: 'auto', width: '100%' }}>
+                <PHQ9ResultsTable responses={responses.entry} />
+            </div>
         </Card>
     )
 }

--- a/src/components/sleep/Sleep.js
+++ b/src/components/sleep/Sleep.js
@@ -14,7 +14,7 @@ const Sleep = ({ observations }) => {
 
     return (
         <Card className="p-2 m-2 d-flex flex-column align-items-center justify-content-center shadow">
-            <p className="lead">Steps</p>
+            <p className="lead">Sleep Duration</p>
             <div style={{ display: 'flex', justifyContent: 'flex-end', alignItems: 'center', marginBottom: '20px' }}>
                 <DatePicker selected={start} onChange={(date) => setStart(date)} />
                 <div style={{ margin: '0 10px' }}>to</div>


### PR DESCRIPTION
# Fixes layout issue on smaller screens

## :recycle: Current situation & Problem
The PHQ-9 responses table is cut off on smaller screens, or iFrames.

## :bulb: Proposed solution
Allows the table to scroll horizontally.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
